### PR TITLE
Only use react-router beta3, not anything higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "object-assign": "^3.0.0",
     "react": "^0.13.3",
     "react-redux": "^0.8.0",
-    "react-router": "^1.0.0-beta3",
+    "react-router": "1.0.0-beta3",
     "redux": "^1.0.0-rc"
   },
   "devDependencies": {


### PR DESCRIPTION
React-Router 1.0.0-beta4 was released today, it broke things.
