### PR TITLE
Add 'start' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "NODE_ENV=production NODE_PATH=$NODE_PATH:./shared node --harmony .",
     "dev": "NODE_PATH=$NODE_PATH:./shared node --harmony .",
     "build": "NODE_ENV=production webpack --progress --color -p --config webpack.prod.config.js"
   },


### PR DESCRIPTION
Sorry, when I remade the previous PR, I forgot to include `package.json`. `start` script requires `NODE_ENV=production` to pass `else` of this condition `process.env.NODE_ENV !== 'production'`, also libraries behave differently in production mode, for example `express-session` warns about MemoryStore not fitting for production, templates are cached into memory, etc.
