### PR TITLE
Prevent double adding of `needs` property in `fetchComponentData`. 

### DIFF
--- a/shared/lib/fetchComponentData.js
+++ b/shared/lib/fetchComponentData.js
@@ -1,9 +1,7 @@
 export default function fetchComponentData(dispatch, components, params) {
   const needs = components.reduce( (prev, current) => {
 
-    return (current.needs || [])
-      .concat((current.WrappedComponent ? current.WrappedComponent.needs : []) || [])
-      .concat(prev);
+    return current ? (current.needs || []).concat(prev) : prev;
   }, []);
 
   const promises = needs.map(need => dispatch(need(params)));

--- a/shared/reducers/TodoReducer.js
+++ b/shared/reducers/TodoReducer.js
@@ -5,7 +5,7 @@ const defaultState = new Immutable.List();
 export default function todoReducer(state = defaultState, action) {
   switch(action.type) {
     case 'GET_TODOS':
-      return state.concat(action.res.data);
+      return new Immutable.List(action.res.data);
     case 'CREATE_TODO':
       return state.concat(action.res.data.text);
     case 'EDIT_TODO':


### PR DESCRIPTION
Fixes #20. No guarantee it will work with other wrappers because AFAICS it's `react-redux` that copies props from the wrapped component into the wrapper, see [connect.js](https://github.com/rackt/react-redux/blob/master/src/components/connect.js#L236) . 
