### PR TITLE
Fix Errors out of browser console.

### DIFF
--- a/shared/components/Home.jsx
+++ b/shared/components/Home.jsx
@@ -1,13 +1,11 @@
-import React, { PropTypes }   from 'react';
+import React, { Component , PropTypes }   from 'react';
 import TodosView              from './TodosView';
 import TodosForm              from './TodosForm';
 import { bindActionCreators } from 'redux';
 import * as TodoActions       from 'actions/TodoActions';
 import { connect }            from 'react-redux';
 
-@connect(state => ({ todos: state.todos }))
-
-export default class Home extends React.Component {
+class Home extends Component {
   static propTypes = {
     todos:    PropTypes.any.isRequired,
     dispatch: PropTypes.func.isRequired
@@ -31,3 +29,5 @@ export default class Home extends React.Component {
     );
   }
 }
+
+export default connect(state => ({ todos: state.todos }))(Home)

--- a/shared/components/Home.jsx
+++ b/shared/components/Home.jsx
@@ -11,12 +11,12 @@ export default class Home extends React.Component {
   static propTypes = {
     todos:    PropTypes.any.isRequired,
     dispatch: PropTypes.func.isRequired
-  }
+  };
 
   static needs = [
     TodoActions.getTodos
-  ]
-  
+  ];
+
   render() {
     const { todos, dispatch } = this.props;
 

--- a/shared/components/TodosForm.jsx
+++ b/shared/components/TodosForm.jsx
@@ -3,7 +3,7 @@ import React, { PropTypes } from 'react';
 export default class TodosForm extends React.Component {
   static propTypes = {
     createTodo: PropTypes.func.isRequired
-  }
+  };
 
   handleSubmit = () => {
     let node = this.refs['todo-input'];
@@ -11,7 +11,7 @@ export default class TodosForm extends React.Component {
     this.props.createTodo(node.value);
 
     node.value = '';
-  }
+  };
 
   render() {
     return (

--- a/shared/components/TodosView.jsx
+++ b/shared/components/TodosView.jsx
@@ -7,13 +7,13 @@ export default class TodosView extends React.Component {
     todos:         PropTypes.instanceOf(Immutable.List).isRequired,
     editTodo:   PropTypes.func.isRequired,
     deleteTodo: PropTypes.func.isRequired
-  }
+  };
 
   handleDelete = (e) => {
     const id = Number(e.target.dataset.id);
 
     this.props.deleteTodo(id);
-  }
+  };
 
   handleEdit = (e) => {
     const id         = Number(e.target.dataset.id);
@@ -23,7 +23,7 @@ export default class TodosView extends React.Component {
     let text = window.prompt('', currentVal);
 
     this.props.editTodo(id, text);
-  }
+  };
 
   render() {
     const btnStyle = {


### PR DESCRIPTION
When I bootstrap the Application ,  there are two Errors I found in my console of browser.
#### A semicolon is required after a class property.

The first problem is about semicolons. The JS specification defines that a semicolon **must** be after a class property. In current Babel v6.3 , It doesn't auto-prefix this.
#### Warning: Failed propType.

When using the `@connect` decorator , class **Home** is decorated as a `ConnectDecorator`.
When setting Home.propTypes, we're actually setting these prop types on the Connector, not on your Info component. So React is enforcing the props in the wrong place! 
**Don't use inheritance please :-)** said by Dan out of [here](https://github.com/rackt/react-redux/issues/6#issuecomment-122261491).
