### PR TITLE
Set `NODE_ENV` through `DefinePlugin` for proper envification.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "NODE_ENV=production NODE_PATH=$NODE_PATH:./shared node --harmony .",
     "dev": "NODE_PATH=$NODE_PATH:./shared node --harmony .",
-    "build": "NODE_ENV=production webpack --progress --color -p --config webpack.prod.config.js"
+    "build": "webpack --progress --color -p --config webpack.prod.config.js"
   },
   "author": "Milo Mordaunt <milomord@gmail.com>",
   "license": "MIT",

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var webpack = require('webpack');
 
 module.exports = {
   entry: [
@@ -22,4 +23,16 @@ module.exports = {
       }
     ]
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"production"'
+      }
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {
+        warnings: false
+      }
+    })
+  ]
 };


### PR DESCRIPTION
Setting `NODE_ENV` this way is a must. The size of the `bundle.js` will be reduced from 330kB to 266kB and the most important part is that the app will be more performant. I've added `UglifyJsPlugin` with `warnings: false` because by default it shows a big and annoying list of warnings.
If you wish we can make this repository more friendlier to Windows users with `cross-env`: `"start": "cross-env NODE_ENV=production NODE_PATH=./shared node --harmony .",`
