### PR TITLE
Add support for redirecting from the server

### DIFF
--- a/server.jsx
+++ b/server.jsx
@@ -31,6 +31,11 @@ app.use( (req, res) => {
       console.error(err);
       return res.status(500).end('Internal server error');
     }
+    
+    if (redirectLocation){
+      const location = redirectLocation.pathname + redirectLocation.search;
+      return res.redirect(302, location);
+    }
 
     if(!renderProps)
       return res.status(404).end('Not found');


### PR DESCRIPTION
Current the server does respond with a `404 not found` if the matched route is a redirect. This pull request changes that behaviour to respond with a `302 found`, a common way to preform an URL redirection.
